### PR TITLE
Fix logout session storage

### DIFF
--- a/src/apiclient.js
+++ b/src/apiclient.js
@@ -489,12 +489,19 @@ class ApiClient {
         return false;
     }
 
+    /**
+    * Logout current user
+    */
     logout() {
 
         stopBitrateDetection(this);
         this.closeWebSocket();
 
         const done = () => {
+            const info = this.serverInfo();
+            if (info && info.UserId && info.Id) {
+                this.appStorage.removeItem(`user-${info.UserId}-${info.Id}`);
+            }
             this.setAuthenticationInfo(null, null);
         };
 


### PR DESCRIPTION
When login out, cleans localStorage.

Same as https://github.com/jellyfin/jellyfin-web/pull/241 but for this repo.

I didn't test it, so I'm not 100% it's working...