### PR TITLE
Assume HTTP for IP

### DIFF
--- a/src/connectionManager.js
+++ b/src/connectionManager.js
@@ -167,7 +167,10 @@ function normalizeAddress(address) {
     // Attempt to correct bad input
     address = address.trim();
 
-    if (!address.toLowerCase().startsWith('http')) {
+    if (/^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}/.test(address)) {
+        // Assume HTTP for IP
+        address = `http://${address}`;
+    } else if (!address.toLowerCase().startsWith('http')) {
         // Assume HTTPS for security
         address = `https://${address}`;
     }


### PR DESCRIPTION
This will remove the need to specify a protocol for IP, assuming that it is `http` instead of `https`.
https://github.com/jellyfin/jellyfin-tizen/issues/33
_But I'm used to specifying the protocol explicitly._

As for regex, we can make it more strict.
https://www.w3resource.com/javascript/form/ip-address-validation.php
https://www.regular-expressions.info/ip.html