### PR TITLE
Add deleteDevice method to ApiClient

### DIFF
--- a/src/apiClient.js
+++ b/src/apiClient.js
@@ -1472,6 +1472,22 @@ class ApiClient {
     }
 
     /**
+     * Deletes the device from the devices list, forcing any active sessions
+     * to re-authenticate.
+     * @param {String} deviceId 
+     */
+    deleteDevice(deviceId) {
+        const url = this.getUrl('Devices', {
+            Id: deviceId
+        });
+
+        return this.ajax({
+            type: 'DELETE',
+            url
+        });
+    }
+
+    /**
      * Gets the current server configuration
      */
     getContentUploadHistory() {


### PR DESCRIPTION
Per PR feedback [here](https://github.com/jellyfin/jellyfin-web/pull/1552), added a new Api Client helper method for deleting a device. I placed it near other device related calls, but the organization of the methods here wasn't super clear to me. Happy to move it elsewhere on the file if there's a more appropriate place for it.