### PR TITLE
SyncPlay for TV series (and Music)

### DIFF
--- a/src/apiClient.js
+++ b/src/apiClient.js
@@ -1524,7 +1524,7 @@ class ApiClient {
     /**
      * Deletes the device from the devices list, forcing any active sessions
      * to re-authenticate.
-     * @param {String} deviceId 
+     * @param {String} deviceId
      */
     deleteDevice(deviceId) {
         const url = this.getUrl('Devices', {
@@ -3394,11 +3394,12 @@ class ApiClient {
 
     /**
      * Creates a SyncPlay group on the server with the current client as member.
+     * @param {object} options Settings for the SyncPlay group to create.
      * @returns {Promise} A Promise fulfilled upon request completion.
      * @since 10.6.0
      */
-    createSyncPlayGroup() {
-        const url = this.getUrl(`SyncPlay/New`);
+    createSyncPlayGroup(options = {}) {
+        const url = this.getUrl(`SyncPlay/New`, options);
 
         return this.ajax({
             type: 'POST',
@@ -3451,12 +3452,87 @@ class ApiClient {
     }
 
     /**
-     * Requests a playback start for the SyncPlay group
+     * Requests a playback play for the SyncPlay group
+     * @param {object} options Options about the new playlist.
      * @returns {Promise} A Promise fulfilled upon request completion.
-     * @since 10.6.0
+     * @since 10.7.0
      */
-    requestSyncPlayStart() {
-        const url = this.getUrl(`SyncPlay/Play`);
+    requestSyncPlayPlay(options = {}) {
+        const url = this.getUrl(`SyncPlay/Play`, options);
+
+        return this.ajax({
+            type: 'POST',
+            url: url
+        });
+    }
+
+    /**
+     * Requests to change playing item in the SyncPlay group
+     * @param {object} options Options about the new playing item.
+     * @returns {Promise} A Promise fulfilled upon request completion.
+     * @since 10.7.0
+     */
+    requestSyncPlaySetPlaylistItem(options = {}) {
+        const url = this.getUrl(`SyncPlay/SetPlaylistItem`, options);
+
+        return this.ajax({
+            type: 'POST',
+            url: url
+        });
+    }
+
+    /**
+     * Requests to remove items from the playlist of the SyncPlay group
+     * @param {object} options Options about the items to remove.
+     * @returns {Promise} A Promise fulfilled upon request completion.
+     * @since 10.7.0
+     */
+    requestSyncPlayRemoveFromPlaylist(options = {}) {
+        const url = this.getUrl(`SyncPlay/RemoveFromPlaylist`, options);
+
+        return this.ajax({
+            type: 'POST',
+            url: url
+        });
+    }
+
+    /**
+     * Requests to move an item in the playlist of the SyncPlay group
+     * @param {object} options Options about the item to move.
+     * @returns {Promise} A Promise fulfilled upon request completion.
+     * @since 10.7.0
+     */
+    requestSyncPlayMovePlaylistItem(options = {}) {
+        const url = this.getUrl(`SyncPlay/MovePlaylistItem`, options);
+
+        return this.ajax({
+            type: 'POST',
+            url: url
+        });
+    }
+
+    /**
+     * Requests to queue items in the playlist of the SyncPlay group
+     * @param {object} options Options about the new items.
+     * @returns {Promise} A Promise fulfilled upon request completion.
+     * @since 10.7.0
+     */
+    requestSyncPlayQueue(options = {}) {
+        const url = this.getUrl(`SyncPlay/Queue`, options);
+
+        return this.ajax({
+            type: 'POST',
+            url: url
+        });
+    }
+
+    /**
+     * Requests a playback unpause for the SyncPlay group
+     * @returns {Promise} A Promise fulfilled upon request completion.
+     * @since 10.7.0
+     */
+    requestSyncPlayUnpause() {
+        const url = this.getUrl(`SyncPlay/Unpause`);
 
         return this.ajax({
             type: 'POST',
@@ -3486,6 +3562,96 @@ class ApiClient {
      */
     requestSyncPlaySeek(options = {}) {
         const url = this.getUrl(`SyncPlay/Seek`, options);
+
+        return this.ajax({
+            type: 'POST',
+            url: url
+        });
+    }
+
+    /**
+     * Requests the next track for the SyncPlay group
+     * @param {object} options Options about the current playlist.
+     * @returns {Promise} A Promise fulfilled upon request completion.
+     * @since 10.7.0
+     */
+    requestSyncPlayNextTrack(options = {}) {
+        const url = this.getUrl(`SyncPlay/NextTrack`, options);
+
+        return this.ajax({
+            type: 'POST',
+            url: url
+        });
+    }
+
+    /**
+     * Requests the previous track for the SyncPlay group
+     * @param {object} options Options about the current playlist.
+     * @returns {Promise} A Promise fulfilled upon request completion.
+     * @since 10.7.0
+     */
+    requestSyncPlayPreviousTrack(options = {}) {
+        const url = this.getUrl(`SyncPlay/PreviousTrack`, options);
+
+        return this.ajax({
+            type: 'POST',
+            url: url
+        });
+    }
+
+    /**
+     * Requests to change repeat mode for the SyncPlay group
+     * @param {object} options Options about the repeat mode.
+     * @returns {Promise} A Promise fulfilled upon request completion.
+     * @since 10.7.0
+     */
+    requestSyncPlaySetRepeatMode(options = {}) {
+        const url = this.getUrl(`SyncPlay/SetRepeatMode`, options);
+
+        return this.ajax({
+            type: 'POST',
+            url: url
+        });
+    }
+
+    /**
+     * Requests to change shuffle mode for the SyncPlay group
+     * @param {object} options Options about the shuffle mode.
+     * @returns {Promise} A Promise fulfilled upon request completion.
+     * @since 10.7.0
+     */
+    requestSyncPlaySetShuffleMode(options = {}) {
+        const url = this.getUrl(`SyncPlay/SetShuffleMode`, options);
+
+        return this.ajax({
+            type: 'POST',
+            url: url
+        });
+    }
+
+    /**
+     * Notifies the server about this client's buffering status
+     * @param {object} options Object containing the buffering status.
+     * @returns {Promise} A Promise fulfilled upon request completion.
+     * @since 10.7.0
+     */
+    requestSyncPlayBuffering(options = {}) {
+        const url = this.getUrl(`SyncPlay/Buffering`, options);
+
+        return this.ajax({
+            type: 'POST',
+            url: url
+        });
+    }
+
+    /**
+     * Requests to change this client's ignore-wait state
+     * @param {object} options Options about the ignore-wait state.
+     * @returns {Promise} A Promise fulfilled upon request completion.
+     * @since 10.7.0
+     */
+    requestSyncPlaySetIgnoreWait(options = {}) {
+        const url = this.getUrl(`SyncPlay/SetIgnoreWait`, options);
 
         return this.ajax({
             type: 'POST',

--- a/src/apiClient.js
+++ b/src/apiClient.js
@@ -3399,11 +3399,13 @@ class ApiClient {
      * @since 10.6.0
      */
     createSyncPlayGroup(options = {}) {
-        const url = this.getUrl(`SyncPlay/New`, options);
+        const url = this.getUrl(`SyncPlay/New`);
 
         return this.ajax({
             type: 'POST',
-            url: url
+            url: url,
+            data: JSON.stringify(options),
+            contentType: 'application/json'
         });
     }
 
@@ -3414,11 +3416,13 @@ class ApiClient {
      * @since 10.6.0
      */
     joinSyncPlayGroup(options = {}) {
-        const url = this.getUrl(`SyncPlay/Join`, options);
+        const url = this.getUrl(`SyncPlay/Join`);
 
         return this.ajax({
             type: 'POST',
-            url: url
+            url: url,
+            data: JSON.stringify(options),
+            contentType: 'application/json'
         });
     }
 
@@ -3443,11 +3447,13 @@ class ApiClient {
      * @since 10.6.0
      */
     sendSyncPlayPing(options = {}) {
-        const url = this.getUrl(`SyncPlay/Ping`, options);
+        const url = this.getUrl(`SyncPlay/Ping`);
 
         return this.ajax({
             type: 'POST',
-            url: url
+            url: url,
+            data: JSON.stringify(options),
+            contentType: 'application/json'
         });
     }
 
@@ -3458,11 +3464,13 @@ class ApiClient {
      * @since 10.7.0
      */
     requestSyncPlayPlay(options = {}) {
-        const url = this.getUrl(`SyncPlay/Play`, options);
+        const url = this.getUrl(`SyncPlay/Play`);
 
         return this.ajax({
             type: 'POST',
-            url: url
+            url: url,
+            data: JSON.stringify(options),
+            contentType: 'application/json'
         });
     }
 
@@ -3473,11 +3481,13 @@ class ApiClient {
      * @since 10.7.0
      */
     requestSyncPlaySetPlaylistItem(options = {}) {
-        const url = this.getUrl(`SyncPlay/SetPlaylistItem`, options);
+        const url = this.getUrl(`SyncPlay/SetPlaylistItem`);
 
         return this.ajax({
             type: 'POST',
-            url: url
+            url: url,
+            data: JSON.stringify(options),
+            contentType: 'application/json'
         });
     }
 
@@ -3488,11 +3498,13 @@ class ApiClient {
      * @since 10.7.0
      */
     requestSyncPlayRemoveFromPlaylist(options = {}) {
-        const url = this.getUrl(`SyncPlay/RemoveFromPlaylist`, options);
+        const url = this.getUrl(`SyncPlay/RemoveFromPlaylist`);
 
         return this.ajax({
             type: 'POST',
-            url: url
+            url: url,
+            data: JSON.stringify(options),
+            contentType: 'application/json'
         });
     }
 
@@ -3503,11 +3515,13 @@ class ApiClient {
      * @since 10.7.0
      */
     requestSyncPlayMovePlaylistItem(options = {}) {
-        const url = this.getUrl(`SyncPlay/MovePlaylistItem`, options);
+        const url = this.getUrl(`SyncPlay/MovePlaylistItem`);
 
         return this.ajax({
             type: 'POST',
-            url: url
+            url: url,
+            data: JSON.stringify(options),
+            contentType: 'application/json'
         });
     }
 
@@ -3518,11 +3532,13 @@ class ApiClient {
      * @since 10.7.0
      */
     requestSyncPlayQueue(options = {}) {
-        const url = this.getUrl(`SyncPlay/Queue`, options);
+        const url = this.getUrl(`SyncPlay/Queue`);
 
         return this.ajax({
             type: 'POST',
-            url: url
+            url: url,
+            data: JSON.stringify(options),
+            contentType: 'application/json'
         });
     }
 
@@ -3561,11 +3577,13 @@ class ApiClient {
      * @since 10.6.0
      */
     requestSyncPlaySeek(options = {}) {
-        const url = this.getUrl(`SyncPlay/Seek`, options);
+        const url = this.getUrl(`SyncPlay/Seek`);
 
         return this.ajax({
             type: 'POST',
-            url: url
+            url: url,
+            data: JSON.stringify(options),
+            contentType: 'application/json'
         });
     }
 
@@ -3576,11 +3594,13 @@ class ApiClient {
      * @since 10.7.0
      */
     requestSyncPlayNextTrack(options = {}) {
-        const url = this.getUrl(`SyncPlay/NextTrack`, options);
+        const url = this.getUrl(`SyncPlay/NextTrack`);
 
         return this.ajax({
             type: 'POST',
-            url: url
+            url: url,
+            data: JSON.stringify(options),
+            contentType: 'application/json'
         });
     }
 
@@ -3591,11 +3611,13 @@ class ApiClient {
      * @since 10.7.0
      */
     requestSyncPlayPreviousTrack(options = {}) {
-        const url = this.getUrl(`SyncPlay/PreviousTrack`, options);
+        const url = this.getUrl(`SyncPlay/PreviousTrack`);
 
         return this.ajax({
             type: 'POST',
-            url: url
+            url: url,
+            data: JSON.stringify(options),
+            contentType: 'application/json'
         });
     }
 
@@ -3606,11 +3628,13 @@ class ApiClient {
      * @since 10.7.0
      */
     requestSyncPlaySetRepeatMode(options = {}) {
-        const url = this.getUrl(`SyncPlay/SetRepeatMode`, options);
+        const url = this.getUrl(`SyncPlay/SetRepeatMode`);
 
         return this.ajax({
             type: 'POST',
-            url: url
+            url: url,
+            data: JSON.stringify(options),
+            contentType: 'application/json'
         });
     }
 
@@ -3621,26 +3645,47 @@ class ApiClient {
      * @since 10.7.0
      */
     requestSyncPlaySetShuffleMode(options = {}) {
-        const url = this.getUrl(`SyncPlay/SetShuffleMode`, options);
+        const url = this.getUrl(`SyncPlay/SetShuffleMode`);
 
         return this.ajax({
             type: 'POST',
-            url: url
+            url: url,
+            data: JSON.stringify(options),
+            contentType: 'application/json'
         });
     }
 
     /**
-     * Notifies the server about this client's buffering status
-     * @param {object} options Object containing the buffering status.
+     * Notifies the server that this client is buffering.
+     * @param {object} options The player status.
      * @returns {Promise} A Promise fulfilled upon request completion.
      * @since 10.7.0
      */
     requestSyncPlayBuffering(options = {}) {
-        const url = this.getUrl(`SyncPlay/Buffering`, options);
+        const url = this.getUrl(`SyncPlay/Buffering`);
 
         return this.ajax({
             type: 'POST',
-            url: url
+            url: url,
+            data: JSON.stringify(options),
+            contentType: 'application/json'
+        });
+    }
+
+    /**
+     * Notifies the server that this client is ready for playback.
+     * @param {object} options The player status.
+     * @returns {Promise} A Promise fulfilled upon request completion.
+     * @since 10.7.0
+     */
+    requestSyncPlayReady(options = {}) {
+        const url = this.getUrl(`SyncPlay/Ready`);
+
+        return this.ajax({
+            type: 'POST',
+            url: url,
+            data: JSON.stringify(options),
+            contentType: 'application/json'
         });
     }
 
@@ -3651,11 +3696,13 @@ class ApiClient {
      * @since 10.7.0
      */
     requestSyncPlaySetIgnoreWait(options = {}) {
-        const url = this.getUrl(`SyncPlay/SetIgnoreWait`, options);
+        const url = this.getUrl(`SyncPlay/SetIgnoreWait`);
 
         return this.ajax({
             type: 'POST',
-            url: url
+            url: url,
+            data: JSON.stringify(options),
+            contentType: 'application/json'
         });
     }
 

--- a/src/apiClient.js
+++ b/src/apiClient.js
@@ -3458,13 +3458,13 @@ class ApiClient {
     }
 
     /**
-     * Requests a playback play for the SyncPlay group
+     * Requests to set a new playlist for the SyncPlay group.
      * @param {object} options Options about the new playlist.
      * @returns {Promise} A Promise fulfilled upon request completion.
      * @since 10.7.0
      */
-    requestSyncPlayPlay(options = {}) {
-        const url = this.getUrl(`SyncPlay/Play`);
+    requestSyncPlaySetNewQueue(options = {}) {
+        const url = this.getUrl(`SyncPlay/SetNewQueue`);
 
         return this.ajax({
             type: 'POST',
@@ -3475,7 +3475,7 @@ class ApiClient {
     }
 
     /**
-     * Requests to change playing item in the SyncPlay group
+     * Requests to change playing item in the SyncPlay group.
      * @param {object} options Options about the new playing item.
      * @returns {Promise} A Promise fulfilled upon request completion.
      * @since 10.7.0
@@ -3492,7 +3492,7 @@ class ApiClient {
     }
 
     /**
-     * Requests to remove items from the playlist of the SyncPlay group
+     * Requests to remove items from the playlist of the SyncPlay group.
      * @param {object} options Options about the items to remove.
      * @returns {Promise} A Promise fulfilled upon request completion.
      * @since 10.7.0
@@ -3509,7 +3509,7 @@ class ApiClient {
     }
 
     /**
-     * Requests to move an item in the playlist of the SyncPlay group
+     * Requests to move an item in the playlist of the SyncPlay group.
      * @param {object} options Options about the item to move.
      * @returns {Promise} A Promise fulfilled upon request completion.
      * @since 10.7.0
@@ -3526,7 +3526,7 @@ class ApiClient {
     }
 
     /**
-     * Requests to queue items in the playlist of the SyncPlay group
+     * Requests to queue items in the playlist of the SyncPlay group.
      * @param {object} options Options about the new items.
      * @returns {Promise} A Promise fulfilled upon request completion.
      * @since 10.7.0
@@ -3543,7 +3543,7 @@ class ApiClient {
     }
 
     /**
-     * Requests a playback unpause for the SyncPlay group
+     * Requests a playback unpause for the SyncPlay group.
      * @returns {Promise} A Promise fulfilled upon request completion.
      * @since 10.7.0
      */
@@ -3557,7 +3557,7 @@ class ApiClient {
     }
 
     /**
-     * Requests a playback pause for the SyncPlay group
+     * Requests a playback pause for the SyncPlay group.
      * @returns {Promise} A Promise fulfilled upon request completion.
      * @since 10.6.0
      */
@@ -3571,7 +3571,7 @@ class ApiClient {
     }
 
     /**
-     * Requests a playback seek for the SyncPlay group
+     * Requests a playback seek for the SyncPlay group.
      * @param {object} options Object containing the requested seek position.
      * @returns {Promise} A Promise fulfilled upon request completion.
      * @since 10.6.0
@@ -3588,13 +3588,13 @@ class ApiClient {
     }
 
     /**
-     * Requests the next track for the SyncPlay group
+     * Requests the next item for the SyncPlay group.
      * @param {object} options Options about the current playlist.
      * @returns {Promise} A Promise fulfilled upon request completion.
      * @since 10.7.0
      */
-    requestSyncPlayNextTrack(options = {}) {
-        const url = this.getUrl(`SyncPlay/NextTrack`);
+    requestSyncPlayNextItem(options = {}) {
+        const url = this.getUrl(`SyncPlay/NextItem`);
 
         return this.ajax({
             type: 'POST',
@@ -3605,13 +3605,13 @@ class ApiClient {
     }
 
     /**
-     * Requests the previous track for the SyncPlay group
+     * Requests the previous item for the SyncPlay group.
      * @param {object} options Options about the current playlist.
      * @returns {Promise} A Promise fulfilled upon request completion.
      * @since 10.7.0
      */
-    requestSyncPlayPreviousTrack(options = {}) {
-        const url = this.getUrl(`SyncPlay/PreviousTrack`);
+    requestSyncPlayPreviousItem(options = {}) {
+        const url = this.getUrl(`SyncPlay/PreviousItem`);
 
         return this.ajax({
             type: 'POST',
@@ -3622,7 +3622,7 @@ class ApiClient {
     }
 
     /**
-     * Requests to change repeat mode for the SyncPlay group
+     * Requests to change repeat mode for the SyncPlay group.
      * @param {object} options Options about the repeat mode.
      * @returns {Promise} A Promise fulfilled upon request completion.
      * @since 10.7.0
@@ -3639,7 +3639,7 @@ class ApiClient {
     }
 
     /**
-     * Requests to change shuffle mode for the SyncPlay group
+     * Requests to change shuffle mode for the SyncPlay group.
      * @param {object} options Options about the shuffle mode.
      * @returns {Promise} A Promise fulfilled upon request completion.
      * @since 10.7.0
@@ -3690,7 +3690,7 @@ class ApiClient {
     }
 
     /**
-     * Requests to change this client's ignore-wait state
+     * Requests to change this client's ignore-wait state.
      * @param {object} options Options about the ignore-wait state.
      * @returns {Promise} A Promise fulfilled upon request completion.
      * @since 10.7.0


### PR DESCRIPTION
**Changes**
This PR aims at making SyncPlay more tv-series friendly, by adding new states that handle the transition between one episode and another.

This PR is related to the [server side one](https://github.com/jellyfin/jellyfin/pull/3194).