### PR TITLE
WebRTC time syncing in SyncPlay

### DIFF
--- a/src/apiClient.js
+++ b/src/apiClient.js
@@ -3738,6 +3738,23 @@ class ApiClient {
         });
     }
 
+    /**
+     * Requests to send a WebRTC related message in SyncPlay group.
+     * @param {object} message The message to send.
+     * @returns {Promise} A Promise fulfilled upon request completion.
+     * @since 10.7.0
+     */
+    requestSyncPlayWebRTC(options = {}) {
+        const url = this.getUrl(`SyncPlay/WebRTC`);
+
+        return this.ajax({
+            type: 'POST',
+            url: url,
+            data: JSON.stringify(options),
+            contentType: 'application/json'
+        });
+    }
+
     createPackageReview(review) {
         const url = this.getUrl(`Packages/Reviews/${review.id}`, review);
 

--- a/src/apiClient.js
+++ b/src/apiClient.js
@@ -3394,6 +3394,20 @@ class ApiClient {
     }
 
     /**
+     * Gets a list of all the users that have access to SyncPlay.
+     * @returns {Promise} A Promise that resolves to the list of available users.
+     * @since 10.7.0
+     */
+    getAvailableSyncPlayUsers() {
+        const url = this.getUrl(`SyncPlay/ListAvailableUsers`);
+
+        return this.ajax({
+            type: 'GET',
+            url: url
+        });
+    }
+
+    /**
      * Creates a SyncPlay group on the server with the current client as member.
      * @param {object} options Settings for the SyncPlay group to create.
      * @returns {Promise} A Promise fulfilled upon request completion.
@@ -3438,6 +3452,23 @@ class ApiClient {
         return this.ajax({
             type: 'POST',
             url: url
+        });
+    }
+
+    /**
+     * Updates the settings of the SyncPlay group.
+     * @param {object} options Settings to set.
+     * @returns {Promise} A Promise fulfilled upon request completion.
+     * @since 10.7.0
+     */
+    updateSyncPlayGroupSettings(options = {}) {
+        const url = this.getUrl(`SyncPlay/Settings`);
+
+        return this.ajax({
+            type: 'POST',
+            url: url,
+            data: JSON.stringify(options),
+            contentType: 'application/json'
         });
     }
 


### PR DESCRIPTION
**Changes**
This PR adds support for WebRTC, making it possible to time sync browsers on the same network.
The experienced playback delay between devices on the same network will be less noticeable (this is the expected result at least).

This PR is related to the [server side one](https://github.com/jellyfin/jellyfin/pull/4329).