### PR TITLE
add dependabot v2 config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,3 @@ updates:
       schedule:
           interval: 'weekly'
       open-pull-requests-limit: 10
-      commit-message:
-          prefix: fix
-          prefix-development: chore
-          include: scope

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,7 @@
 version: 2
 updates:
     - package-ecosystem: npm
-      directory: '/'
+      directory: /
       schedule:
-          interval: 'weekly'
+          interval: weekly
       open-pull-requests-limit: 10

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+    - package-ecosystem: npm
+      directory: '/'
+      schedule:
+          interval: 'weekly'
+      open-pull-requests-limit: 10
+      commit-message:
+          prefix: fix
+          prefix-development: chore
+          include: scope


### PR DESCRIPTION
**Description**

Saw #71 and thought to myself why not use Dependabot v2 from the get go?
So here a alternative using v2 (if this gets accepted over #71 ill open the same PR to web)

NOTE: yes the npm package manager seem too work fine in this case (+ according tho the [docs](https://docs.github.com/en/free-pro-team@latest/github/administering-a-repository/configuration-options-for-dependency-updates#package-ecosystem), see the note at the bottom of the table). If you want to see it in action check out the master of my fork there I tested this :wink: 

**Changes**

* add Depenndabot v2 config

**Issues**

* N/A