### PR TITLE
Fix to resolve issue with sendMessageCommand

### DIFF
--- a/src/apiClient.js
+++ b/src/apiClient.js
@@ -3412,18 +3412,13 @@ class ApiClient {
         if (!options) {
             throw new Error('null options');
         }
+        
+        const url = this.getUrl(`Sessions/${sessionId}/Message`, options || {});
 
-        const url = this.getUrl(`Sessions/${sessionId}/Message`);
-
-        const ajaxOptions = {
+        return this.ajax({
             type: 'POST',
             url
-        };
-
-        ajaxOptions.data = JSON.stringify(options);
-        ajaxOptions.contentType = 'application/json';
-
-        return this.ajax(ajaxOptions);
+        });
     }
 
     sendPlayStateCommand(sessionId, command, options) {


### PR DESCRIPTION
Fix to resolve issue with sendMessageCommand incorrectly sending parameters in body, rather than sending them in query string as required by the SessionController API on the server.

Resolves: #173