### PR TITLE
Fix fake LoggedIn state

### DIFF
--- a/src/apiClient.js
+++ b/src/apiClient.js
@@ -138,6 +138,7 @@ class ApiClient {
         this._deviceName = deviceName;
         this._appName = appName;
         this._appVersion = appVersion;
+        this._loggedIn = false;
     }
 
     appName() {
@@ -363,6 +364,8 @@ class ApiClient {
     setAuthenticationInfo(accessKey, userId) {
         this._currentUser = null;
 
+        this._loggedIn = !!userId && !!accessKey;
+
         this._serverInfo.AccessToken = accessKey;
         this._serverInfo.UserId = userId;
         redetectBitrate(this);
@@ -380,10 +383,12 @@ class ApiClient {
      * Gets or sets the current user id.
      */
     getCurrentUserId() {
+        if (!this._loggedIn) return null;
         return this._serverInfo.UserId;
     }
 
     accessToken() {
+        if (!this._loggedIn) return null;
         return this._serverInfo.AccessToken;
     }
 
@@ -455,14 +460,7 @@ class ApiClient {
     }
 
     isLoggedIn() {
-        const info = this.serverInfo();
-        if (info) {
-            if (info.UserId && info.AccessToken) {
-                return true;
-            }
-        }
-
-        return false;
+        return this._loggedIn;
     }
 
     /**

--- a/src/connectionManager.js
+++ b/src/connectionManager.js
@@ -340,6 +340,7 @@ export default class ConnectionManager {
             apiClient.enableAutomaticBitrateDetection = options.enableAutomaticBitrateDetection;
 
             apiClient.serverInfo(server);
+            apiClient.setAuthenticationInfo(result.AccessToken, result.User.Id);
             afterConnected(apiClient, options);
 
             return onLocalUserSignIn(server, apiClient.serverAddress(), result.User);
@@ -739,6 +740,7 @@ export default class ConnectionManager {
             result.ApiClient.enableAutomaticBitrateDetection = options.enableAutomaticBitrateDetection;
 
             result.ApiClient.updateServerInfo(server, serverUrl);
+            result.ApiClient.setAuthenticationInfo(server.AccessToken, server.UserId);
 
             const resolveActions = function () {
                 resolve(result);


### PR DESCRIPTION
The idea: `_loggedIn` flag is unset until we pass authentication (it is more verification of server id and access token).
The flag is set by `setAuthenticationInfo` - the end of the authentication process.

**Verified situations**
- Server ID changed
https://github.com/jellyfin/jellyfin-apiclient-javascript/blob/4da66764026a1cd3b4f7da4207a42295153a17aa/src/connectionManager.js#L692

- Invalid access token
https://github.com/jellyfin/jellyfin-apiclient-javascript/blob/4da66764026a1cd3b4f7da4207a42295153a17aa/src/connectionManager.js#L387-L389

This probably fixes the connection issue when the server IP changes (standalone, bundled webs).

This doesn't fix "Valid Token + Invalid User": we pass with a valid token, but we can't fetch anything.

_This is 1 of 2 versions of the fix._
_In `2`, apiClients store own copy of server info. But there are changes in server info fields all over the place (`DateLastAccessed`, `LastConnectionMode`, etc.)._
_IMO, `1` is less destructive, but I prefer `2` ¯\\\_(ツ)\_/¯_

`2`: https://github.com/jellyfin/jellyfin-apiclient-javascript/tree/fix-fake-loggedin-2