### PR TITLE
Add GH action for npm publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,41 @@
+name: Build and publish to NPM
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        ref: 'master'
+
+    - name: Setup node environment for npm
+      uses: actions/setup-node@v2.1.5
+      with:
+        node-version: 14
+        registry-url: 'https://registry.npmjs.org'
+
+    - name: Get yarn cache directory path
+      id: yarn-cache-dir-path
+      run: echo "::set-output name=dir::$(yarn cache dir)"
+
+    - name: Cache node_modules
+      uses: actions/cache@v2.1.5
+      id: yarn-cache
+      with:
+        path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+        key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-yarn-
+
+    - name: Install dependencies
+      run: yarn install --frozen-lockfile
+
+    - name: Publish to npm
+      run: npm publish --access public
+      env:
+        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "Firefox ESR"
   ],
   "scripts": {
-    "prepare": "webpack",
+    "prepare": "webpack --mode production",
     "dev": "webpack --mode development",
     "build": "webpack --mode production",
     "lint": "eslint \"src\"",


### PR DESCRIPTION
Adds a GitHub action to publish this package to npm when a new release is published

I tested this locally with the [act](https://github.com/nektos/act) utility and it seems to work as expected :crossed_fingers: 