### PR TITLE
Add dependabot config for GH actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,9 @@ updates:
       schedule:
           interval: weekly
       open-pull-requests-limit: 10
+
+    - package-ecosystem: github-actions
+      directory: /
+      schedule:
+        interval: weekly
+      open-pull-requests-limit: 10


### PR DESCRIPTION
Adds GitHub Actions to the dependabot configuration