### PR TITLE
Bump version to 1.9.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "jellyfin-apiclient",
-  "version": "1.8.0",
+  "version": "1.9.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jellyfin-apiclient",
-  "version": "1.8.0",
+  "version": "1.9.0",
   "description": "API client for Jellyfin",
   "main": "dist/jellyfin-apiclient.js",
   "dependencies": {},


### PR DESCRIPTION
Bumps the version to include the newest Quick Connect changes from https://github.com/jellyfin/jellyfin-apiclient-javascript/pull/284

Here are the full [release notes](https://gist.github.com/thornbill/573bcd027dc3770e334a2e0f6c7c751a).