### PR TITLE
Bump version to 1.9.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "jellyfin-apiclient",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jellyfin-apiclient",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "description": "API client for Jellyfin",
   "main": "dist/jellyfin-apiclient.js",
   "dependencies": {},


### PR DESCRIPTION
Bumps the version to fix the build not properly targeting ES5. (Fixed in #304)

[Draft Release](https://github.com/jellyfin/jellyfin-apiclient-javascript/releases/tag/untagged-b662a259aa9801a459c4)