### PR TITLE
Fix extra Promise creation when reporting progress

### DIFF
--- a/src/apiClient.js
+++ b/src/apiClient.js
@@ -3254,7 +3254,7 @@ class ApiClient {
         const msSinceLastReport = now - (this.lastPlaybackProgressReport || 0);
         const newPositionTicks = options.PositionTicks;
 
-        if (msSinceLastReport < reportRateLimitTime && eventName === 'timeupdate' && newPositionTicks) {
+        if (msSinceLastReport < reportRateLimitTime && eventName === 'timeupdate' && newPositionTicks != null) {
             const expectedReportTicks = 1e4 * msSinceLastReport + (this.lastPlaybackProgressReportTicks || 0);
             if (Math.abs(newPositionTicks - expectedReportTicks) >= 5e7) reportRateLimitTime = 0;
         }

--- a/src/promiseDelay.js
+++ b/src/promiseDelay.js
@@ -1,0 +1,52 @@
+/**
+ * Creates a new delayed Promise instance.
+ * @param {number} ms Delay in milliseconds.
+ */
+export default class PromiseDelay {
+    constructor(ms) {
+        this._fulfilled = false;
+        this._promise = new Promise((resolve, reject) => {
+            this._promiseResolve = resolve;
+            this._promiseReject = reject;
+            this.reset(ms);
+        });
+    }
+
+    /**
+     * Delayed promise.
+     * @returns {Promise} A Promise fulfilled after timeout.
+     */
+    promise() {
+        return this._promise;
+    }
+
+    /**
+     * Resets delay.
+     * @param {number} ms New delay in milliseconds.
+     */
+    reset(ms) {
+        if (this._fulfilled) return;
+        clearTimeout(this._timer);
+        this._timer = setTimeout(() => this.resolve(), ms);
+    }
+
+    /**
+     * Immediately resolves delayed Promise.
+     */
+    resolve() {
+        if (this._fulfilled) return;
+        clearTimeout(this._timer);
+        this._fulfilled = true;
+        this._promiseResolve();
+    }
+
+    /**
+     * Immediately rejects delayed Promise.
+     */
+    reject() {
+        if (this._fulfilled) return;
+        clearTimeout(this._timer);
+        this._fulfilled = true;
+        this._promiseReject();
+    }
+}


### PR DESCRIPTION
The previous implementation could not change the timeout, so Promise was simply abandoned (with `canceled` mark), and a new one was created for a new progress report. This turned into 2 Promises at the same time (in theory, even 3 at the same time: `timeupdate + volume + pause`).

**Changes**
- Now only one Promise is used for scheduled reporting, and it is reused until it fulfilled.
- A real zero position (`PositionTicks: 0`) is also checked for the far jump.

I left `resetReportPlaybackProgress` with `resolve: false`, which means that the last report won't be sent (as it was), because this seems to work fine. But if we need to send the last report before stopping, we can change it to `resolve: true`.