### PR TITLE
Bump ecmaVersion and update environment for ESLint

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -1,6 +1,8 @@
 env:
   es6: true
   browser: true
+  es2017: true
+  es2020: true
 
 extends:
   - "eslint:recommended"
@@ -18,7 +20,7 @@ rules:
   promise/no-return-wrap: ["warn"]
 
 parserOptions:
-  ecmaVersion: 6
+  ecmaVersion: 2020
   sourceType: module
 
 overrides:


### PR DESCRIPTION
**Changes**
Bump `ecmaVersion` [as in web](https://github.com/jellyfin/jellyfin-web/blob/b9726b7ec881d862f0adba34860071d81f124738/.eslintrc.js#L19).

**Issues**
Linting error in #383: ESLint doesn't recognize `async function` with `ecmaVersion: 6`.

Should I add `es2017` and `es2020` here ([as in web](https://github.com/jellyfin/jellyfin-web/blob/b9726b7ec881d862f0adba34860071d81f124738/.eslintrc.js#L15-L16))?
https://github.com/jellyfin/jellyfin-apiclient-javascript/blob/312d668e84e4e24e58d327bb3a20ecaac8457d08/.eslintrc.yml#L1-L3
