### PR TITLE
Replace deprecated String.prototype.substr()

### DIFF
--- a/src/apiClientCore.js
+++ b/src/apiClientCore.js
@@ -34,7 +34,7 @@ function startsWith(str, find) {
 
 function stripStart(str, find) {
     if (startsWith(str, find)) {
-        return str.substr(find.length);
+        return str.slice(find.length);
     }
 
     return str;


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.